### PR TITLE
MULE-19144: Adding more information to XmlMetadataAnnotations.

### DIFF
--- a/src/main/java/org/mule/runtime/dsl/api/xml/parser/ConfigLine.java
+++ b/src/main/java/org/mule/runtime/dsl/api/xml/parser/ConfigLine.java
@@ -111,16 +111,14 @@ public final class ConfigLine {
   }
 
   /**
-   * @return the first line number in which the config line was defined in the configuration file. For compatibility reasons, this
-   *         line will be the last line of the opening tag (only makes a difference for multi-line opening tags).
+   * @return the first line number in which the config line was defined in the configuration file.
    */
   public int getLineNumber() {
     return lineNumber;
   }
 
   /**
-   * @return the start column in which the config line was defined in the configuration file. For consistency with
-   *         {@link #getLineNumber()}, this column number will be the last column of the opening tag.
+   * @return the start column in which the config line was defined in the configuration file.
    */
   public int getStartColumn() {
     return startColumn;

--- a/src/main/java/org/mule/runtime/dsl/api/xml/parser/ConfigLine.java
+++ b/src/main/java/org/mule/runtime/dsl/api/xml/parser/ConfigLine.java
@@ -110,10 +110,18 @@ public final class ConfigLine {
     return textContent;
   }
 
+  /**
+   * @return the first line number in which the config line was defined in the configuration file. For compatibility reasons, this
+   *         line will be the last line of the opening tag (only makes a difference for multi-line opening tags).
+   */
   public int getLineNumber() {
     return lineNumber;
   }
 
+  /**
+   * @return the start column in which the config line was defined in the configuration file. For consistency with
+   *         {@link #getLineNumber()}, this column number will be the last column of the opening tag.
+   */
   public int getStartColumn() {
     return startColumn;
   }

--- a/src/main/java/org/mule/runtime/dsl/api/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/api/xml/parser/XmlApplicationParser.java
@@ -44,15 +44,6 @@ public class XmlApplicationParser {
   public static final String LINE_NUMBER = "LINE_NUMBER";
   public static final String CONFIG_FILE_NAME = "CONFIG_FILE_NAME";
   public static final String IS_CDATA = "IS_CDATA";
-  public static final String OPENING_TAG_START_LINE = "OPENING_TAG_START_LINE";
-  public static final String OPENING_TAG_START_COLUMN = "OPENING_TAG_START_COLUMN";
-  public static final String OPENING_TAG_END_LINE = "OPENING_TAG_END_LINE";
-  public static final String OPENING_TAG_END_COLUMN = "OPENING_TAG_END_COLUMN";
-  public static final String CLOSING_TAG_START_LINE = "CLOSING_TAG_START_LINE";
-  public static final String CLOSING_TAG_START_COLUMN = "CLOSING_TAG_START_COLUMN";
-  public static final String CLOSING_TAG_END_LINE = "CLOSING_TAG_END_LINE";
-  public static final String CLOSING_TAG_END_COLUMN = "CLOSING_TAG_END_COLUMN";
-  public static final String IS_SELF_CLOSING = "IS_SELF_CLOSING";
 
   private static final String COLON = ":";
   private static final Map<String, String> predefinedNamespace = new HashMap<>();

--- a/src/main/java/org/mule/runtime/dsl/api/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/api/xml/parser/XmlApplicationParser.java
@@ -44,6 +44,15 @@ public class XmlApplicationParser {
   public static final String LINE_NUMBER = "LINE_NUMBER";
   public static final String CONFIG_FILE_NAME = "CONFIG_FILE_NAME";
   public static final String IS_CDATA = "IS_CDATA";
+  public static final String OPENING_TAG_START_LINE = "OPENING_TAG_START_LINE";
+  public static final String OPENING_TAG_START_COLUMN = "OPENING_TAG_START_COLUMN";
+  public static final String OPENING_TAG_END_LINE = "OPENING_TAG_END_LINE";
+  public static final String OPENING_TAG_END_COLUMN = "OPENING_TAG_END_COLUMN";
+  public static final String CLOSING_TAG_START_LINE = "CLOSING_TAG_START_LINE";
+  public static final String CLOSING_TAG_START_COLUMN = "CLOSING_TAG_START_COLUMN";
+  public static final String CLOSING_TAG_END_LINE = "CLOSING_TAG_END_LINE";
+  public static final String CLOSING_TAG_END_COLUMN = "CLOSING_TAG_END_COLUMN";
+  public static final String IS_SELF_CLOSING = "IS_SELF_CLOSING";
 
   private static final String COLON = ":";
   private static final Map<String, String> predefinedNamespace = new HashMap<>();

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/DefaultXmlMetadataAnnotations.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/DefaultXmlMetadataAnnotations.java
@@ -25,7 +25,6 @@ public class DefaultXmlMetadataAnnotations implements XmlMetadataAnnotations {
    * compact whitespaces and line breaks
    */
   private static final Pattern COMPACT_PATTERN = compile(">\\s+<+");
-  public static final String METADATA_ANNOTATIONS_KEY = "metadataAnnotations";
 
   private static final Pattern URL_PATTERN = compile("url=\"[a-z]*://([^@]*)@");
   private static final Pattern ADDRESS_PATTERN = compile("address=\"[a-z]*://([^@]*)@");
@@ -34,8 +33,9 @@ public class DefaultXmlMetadataAnnotations implements XmlMetadataAnnotations {
   private static final String PASSWORD_ATTRIBUTE_MASK = "password=\"%s\"";
 
   private final StringBuilder xmlContent = new StringBuilder();
-  private int lineNumber;
-  private int columnNumber;
+
+  private final TagBoundaries openingTagBoundaries = new DefaultTagBoundaries();
+  private final TagBoundaries closingTagBoundaries = new DefaultTagBoundaries();
 
   /**
    * Builds the opening tag of the xml element.
@@ -84,35 +84,29 @@ public class DefaultXmlMetadataAnnotations implements XmlMetadataAnnotations {
   }
 
   /**
-   * @param lineNumber the line where the declaration of the element starts in its source xml file.
+   * @return Whether the element was written as in {@code <element />} in the source code. In such case, the opening and closing
+   *         tag boundaries will be the same, as both tags are merged into one.
    */
   @Override
-  public void setLineNumber(int lineNumber) {
-    this.lineNumber = lineNumber;
+  public boolean isSelfClosing() {
+    return openingTagBoundaries.getStartLineNumber() == closingTagBoundaries.getStartLineNumber() &&
+        openingTagBoundaries.getStartColumnNumber() == closingTagBoundaries.getStartColumnNumber();
   }
 
   /**
-   * @return the line where the declaration of the element starts in its source xml file.
+   * @return the boundaries of the opening tag on the source xml file.
    */
   @Override
-  public int getLineNumber() {
-    return lineNumber;
+  public TagBoundaries getOpeningTagBoundaries() {
+    return openingTagBoundaries;
   }
 
   /**
-   * @param columnNumber the column where the declaration of the element starts in the source xml file.
+   * @return the boundaries of the closing tag on the source xml file.
    */
   @Override
-  public void setColumnNumber(int columnNumber) {
-    this.columnNumber = columnNumber;
-  }
-
-  /**
-   * @return the column where the declaration of the element starts in the source xml file.
-   */
-  @Override
-  public int getColumnNumber() {
-    return columnNumber;
+  public TagBoundaries getClosingTagBoundaries() {
+    return closingTagBoundaries;
   }
 
   private static String maskPasswords(String xml, String passwordMask) {
@@ -142,5 +136,53 @@ public class DefaultXmlMetadataAnnotations implements XmlMetadataAnnotations {
 
   private static String maskPasswordAttribute(String password) {
     return format(PASSWORD_ATTRIBUTE_MASK, password);
+  }
+
+  private static class DefaultTagBoundaries implements TagBoundaries {
+
+    private int startLineNumber;
+    private int startColumnNumber;
+    private int endLineNumber;
+    private int endColumnNumber;
+
+    @Override
+    public int getStartLineNumber() {
+      return startLineNumber;
+    }
+
+    @Override
+    public void setStartLineNumber(int lineNumber) {
+      this.startLineNumber = lineNumber;
+    }
+
+    @Override
+    public int getStartColumnNumber() {
+      return startColumnNumber;
+    }
+
+    @Override
+    public void setStartColumnNumber(int columnNumber) {
+      this.startColumnNumber = columnNumber;
+    }
+
+    @Override
+    public int getEndLineNumber() {
+      return endLineNumber;
+    }
+
+    @Override
+    public void setEndLineNumber(int lineNumber) {
+      this.endLineNumber = lineNumber;
+    }
+
+    @Override
+    public int getEndColumnNumber() {
+      return endColumnNumber;
+    }
+
+    @Override
+    public void setEndColumnNumber(int columnNumber) {
+      this.endColumnNumber = columnNumber;
+    }
   }
 }

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoader.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoader.java
@@ -11,10 +11,10 @@ import static java.lang.Thread.currentThread;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.mule.apache.xerces.impl.xs.SchemaValidatorHelper.XMLGRAMMAR_POOL;
 import static org.mule.runtime.dsl.internal.xml.parser.XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY;
-import static org.mule.runtime.internal.util.xmlsecurity.DefaultXMLSecureFactories.DOCUMENT_BUILDER_FACTORY;
 
 import org.mule.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.mule.runtime.dsl.internal.SourcePosition;
+import org.mule.runtime.dsl.internal.xml.parser.XmlMetadataAnnotations.TagBoundaries;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -206,7 +207,7 @@ final public class MuleDocumentLoader {
       metadataBuilder.getOpeningTagBoundaries().setStartColumnNumber(trackingPoint.getColumn() - trackingPointOffset);
       metadataBuilder.getOpeningTagBoundaries().setEndLineNumber(locator.getLineNumber());
       metadataBuilder.getOpeningTagBoundaries().setEndColumnNumber(locator.getColumnNumber());
-      LinkedHashMap<String, String> attsMap = new LinkedHashMap<>();
+      Map<String, String> attsMap = new LinkedHashMap<>();
       for (int i = 0; i < atts.getLength(); ++i) {
         attsMap.put(atts.getQName(i), atts.getValue(i));
       }
@@ -294,7 +295,7 @@ final public class MuleDocumentLoader {
       // checks if the current tracking point is still at the same place of the opening tag starting point
       // if so, it means the element was written as a self-closing tag (e.g.: <element />), which means we should use
       // the same offset as for an opening.
-      XmlMetadataAnnotations.TagBoundaries openingTagBoundaries = metadataAnnotations.getOpeningTagBoundaries();
+      TagBoundaries openingTagBoundaries = metadataAnnotations.getOpeningTagBoundaries();
       if (openingTagBoundaries.getStartLineNumber() == trackingPoint.getLine() &&
           openingTagBoundaries.getStartColumnNumber() == trackingPoint.getColumn() - OPENING_TRACKING_POINT_OFFSET) {
         return OPENING_TRACKING_POINT_OFFSET;

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
@@ -65,8 +65,9 @@ public final class XmlApplicationParser {
         .setNamespaceUri(namespaceUri);
 
     XmlMetadataAnnotations userData = (XmlMetadataAnnotations) node.getUserData(XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY);
-    builder.setLineNumber(userData.getOpeningTagBoundaries().getStartLineNumber())
-        .setStartColumn(userData.getOpeningTagBoundaries().getStartColumnNumber())
+    // for compatibility reasons we set the position of the end of the opening tag instead of the start
+    builder.setLineNumber(userData.getOpeningTagBoundaries().getEndLineNumber())
+        .setStartColumn(userData.getOpeningTagBoundaries().getEndColumnNumber())
         .setSourceCode(userData.getElementString());
 
     XmlCustomAttributeHandler.to(builder).addCustomAttributes(node);

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
@@ -65,9 +65,8 @@ public final class XmlApplicationParser {
         .setNamespaceUri(namespaceUri);
 
     XmlMetadataAnnotations userData = (XmlMetadataAnnotations) node.getUserData(XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY);
-    // for compatibility reasons we set the position of the end of the opening tag instead of the start
-    builder.setLineNumber(userData.getOpeningTagBoundaries().getEndLineNumber())
-        .setStartColumn(userData.getOpeningTagBoundaries().getEndColumnNumber())
+    builder.setLineNumber(userData.getOpeningTagBoundaries().getStartLineNumber())
+        .setStartColumn(userData.getOpeningTagBoundaries().getStartColumnNumber())
         .setSourceCode(userData.getElementString());
 
     XmlCustomAttributeHandler.to(builder).addCustomAttributes(node);

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
@@ -8,6 +8,7 @@
 package org.mule.runtime.dsl.internal.xml.parser;
 
 import static java.util.Optional.empty;
+import static org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.IS_CDATA;
 
 import org.mule.runtime.dsl.api.xml.XmlNamespaceInfoProvider;
 import org.mule.runtime.dsl.api.xml.parser.ConfigLine;
@@ -31,20 +32,10 @@ import org.w3c.dom.NodeList;
  */
 public final class XmlApplicationParser {
 
-  public static final String DECLARED_PREFIX = org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.DECLARED_PREFIX;
-  public static final String XML_NODE = org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.XML_NODE;
-  public static final String LINE_NUMBER = org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.LINE_NUMBER;
-  public static final String CONFIG_FILE_NAME = org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.CONFIG_FILE_NAME;
-  public static final String IS_CDATA = org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.IS_CDATA;
-
   private final org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser parser;
 
   public XmlApplicationParser(List<XmlNamespaceInfoProvider> namespaceInfoProviders) {
     parser = new org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser(namespaceInfoProviders);
-  }
-
-  public String getNormalizedNamespace(String namespaceUri, String namespacePrefix) {
-    return parser.getNormalizedNamespace(namespaceUri, namespacePrefix);
   }
 
   /**

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlApplicationParser.java
@@ -74,9 +74,9 @@ public final class XmlApplicationParser {
         .setNamespaceUri(namespaceUri);
 
     XmlMetadataAnnotations userData = (XmlMetadataAnnotations) node.getUserData(XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY);
-    int lineNumber = userData.getLineNumber();
-    builder.setLineNumber(lineNumber).setStartColumn(userData.getColumnNumber());
-    builder.setSourceCode(userData.getElementString());
+    builder.setLineNumber(userData.getOpeningTagBoundaries().getStartLineNumber())
+        .setStartColumn(userData.getOpeningTagBoundaries().getStartColumnNumber())
+        .setSourceCode(userData.getElementString());
 
     XmlCustomAttributeHandler.to(builder).addCustomAttributes(node);
 

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlCustomAttributeHandler.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlCustomAttributeHandler.java
@@ -8,7 +8,7 @@ package org.mule.runtime.dsl.internal.xml.parser;
 
 
 import static org.mule.runtime.api.component.Component.Annotations.NAME_ANNOTATION_KEY;
-import static org.mule.runtime.dsl.internal.xml.parser.XmlApplicationParser.DECLARED_PREFIX;
+import static org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.DECLARED_PREFIX;
 
 import org.mule.runtime.dsl.api.xml.parser.ConfigLine;
 

--- a/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlMetadataAnnotations.java
+++ b/src/main/java/org/mule/runtime/dsl/internal/xml/parser/XmlMetadataAnnotations.java
@@ -16,6 +16,49 @@ import java.util.Map;
 @NoImplement
 public interface XmlMetadataAnnotations {
 
+  interface TagBoundaries {
+
+    /**
+     * @return the line where the declaration of the tag starts in its source xml file.
+     */
+    int getStartLineNumber();
+
+    /**
+     * @param lineNumber the line where the declaration of the tag starts in its source xml file.
+     */
+    void setStartLineNumber(int lineNumber);
+
+    /**
+     * @return the column where the declaration of the tag starts in the source xml file.
+     */
+    int getStartColumnNumber();
+
+    /**
+     * @param columnNumber the column where the declaration of the tag starts in the source xml file.
+     */
+    void setStartColumnNumber(int columnNumber);
+
+    /**
+     * @return the line where the declaration of the tag ends in its source xml file.
+     */
+    int getEndLineNumber();
+
+    /**
+     * @param lineNumber the line where the declaration of the tag ends in its source xml file.
+     */
+    void setEndLineNumber(int lineNumber);
+
+    /**
+     * @return the column where the declaration of the tag ends in the source xml file.
+     */
+    int getEndColumnNumber();
+
+    /**
+     * @param columnNumber the column where the declaration of the tag ends in the source xml file.
+     */
+    void setEndColumnNumber(int columnNumber);
+  }
+
   String METADATA_ANNOTATIONS_KEY = "metadataAnnotations";
 
   /**
@@ -49,22 +92,18 @@ public interface XmlMetadataAnnotations {
   String getElementString();
 
   /**
-   * @return the line where the declaration of the element starts in its source xml file.
+   * @return Whether the element was written as in {@code <element />}. In such case, the opening and closing tag boundaries will
+   *         be the same.
    */
-  int getLineNumber();
+  boolean isSelfClosing();
 
   /**
-   * @param lineNumber the line where the declaration of the element starts in its source xml file.
+   * @return the boundaries of the opening tag on the source xml file.
    */
-  void setLineNumber(int lineNumber);
+  TagBoundaries getOpeningTagBoundaries();
 
   /**
-   * @return the column where the declaration of the element starts in the source xml file.
+   * @return the boundaries of the closing tag on the source xml file.
    */
-  int getColumnNumber();
-
-  /**
-   * @param columnNumber the column where the declaration of the element starts in the source xml file.
-   */
-  void setColumnNumber(int columnNumber);
+  TagBoundaries getClosingTagBoundaries();
 }

--- a/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
+++ b/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
@@ -119,4 +119,61 @@ public class MuleDocumentLoaderTestCase {
     assertThat(loggerAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(8));
     assertThat(loggerAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(75));
   }
+
+  @Test
+  public void xmlMetadataIsProperlyPopulatedWhenWhitespaceBetweenLineFeed() throws Exception {
+
+    InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("simple_application_with_whitespace_between_linefeed.xml");
+    MuleDocumentLoader loader = new MuleDocumentLoader();
+
+    InputSource is = new InputSource(inputStream);
+    XmlGathererErrorHandler errorHandler = new DefaultXmlGathererErrorHandlerFactory().create();
+    Document document = loader.loadDocument(SAXParserFactory::newInstance, is, null, errorHandler, 0, false, null);
+
+    assertThat(document, is(notNullValue()));
+    assertThat(errorHandler.getErrors().size(), is(0));
+
+    XmlMetadataAnnotations rootAnnotations =
+            (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(rootAnnotations, is(not(nullValue())));
+    assertThat(rootAnnotations.isSelfClosing(), is(false));
+    // FIXME: these are currently returning the beginning of the document instead of the beginning of the first tag
+    // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(2));
+    // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(1));
+    assertThat(rootAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(5));
+    assertThat(rootAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(108));
+
+    assertThat(rootAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(13));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(1));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(13));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(8));
+
+    XmlMetadataAnnotations flowAnnotations =
+            (XmlMetadataAnnotations) document.getElementsByTagName("flow").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(flowAnnotations, is(not(nullValue())));
+    assertThat(flowAnnotations.isSelfClosing(), is(false));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(9));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(5));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(9));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(23));
+
+    assertThat(flowAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(11));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(5));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(11));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(12));
+
+    XmlMetadataAnnotations loggerAnnotations =
+            (XmlMetadataAnnotations) document.getElementsByTagName("logger").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(loggerAnnotations, is(not(nullValue())));
+    assertThat(loggerAnnotations.isSelfClosing(), is(true));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(10));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(9));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(10));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(75));
+
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(10));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(9));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(10));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(75));
+  }
 }

--- a/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
+++ b/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
@@ -7,13 +7,14 @@
 package org.mule.runtime.dsl.internal.xml.parser;
 
 import static java.lang.Thread.currentThread;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.mock;
+import static org.mule.runtime.dsl.internal.xml.parser.XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY;
 
 import io.qameta.allure.Issue;
 import org.junit.After;
@@ -24,21 +25,10 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.SAXParserFactory;
+import java.io.InputStream;
 import java.net.URLClassLoader;
 
 public class MuleDocumentLoaderTestCase {
-
-  private static final String SIMPLE_APPLICATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-      "<mule xmlns=\"http://www.mulesoft.org/schema/mule/core\"\n" +
-      "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-      "      xsi:schemaLocation=\"\n" +
-      "       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\">\n" +
-      "\n" +
-      "    <flow name=\"test\">\n" +
-      "        <logger category=\"SOMETHING\" level=\"WARN\" message=\"logging info\"/>\n" +
-      "    </flow>\n" +
-      "\n" +
-      "</mule>";
 
   private ClassLoader originalClassLoader;
 
@@ -56,13 +46,14 @@ public class MuleDocumentLoaderTestCase {
   @Issue("MULE-18813")
   public void documentLoaderShouldNotUseThreadCurrentClassLoader() throws Exception {
 
+    InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("simple_application.xml");
     MuleDocumentLoader loader = new MuleDocumentLoader();
 
     // Setting failure class loader
     URLClassLoader failing = mock(URLClassLoader.class);
     currentThread().setContextClassLoader(failing);
 
-    InputSource is = new InputSource(toInputStream(SIMPLE_APPLICATION, UTF_8));
+    InputSource is = new InputSource(inputStream);
     XmlGathererErrorHandler errorHandler = new DefaultXmlGathererErrorHandlerFactory().create();
     Document document = loader.loadDocument(SAXParserFactory::newInstance, is, null, errorHandler, 0, false, null);
 
@@ -70,5 +61,62 @@ public class MuleDocumentLoaderTestCase {
 
     assertThat(document, is(notNullValue()));
     assertThat(errorHandler.getErrors().size(), is(0));
+  }
+
+  @Test
+  public void xmlMetadataIsProperlyPopulatedWhenParsingSimpleApplication() throws Exception {
+
+    InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("simple_application.xml");
+    MuleDocumentLoader loader = new MuleDocumentLoader();
+
+    InputSource is = new InputSource(inputStream);
+    XmlGathererErrorHandler errorHandler = new DefaultXmlGathererErrorHandlerFactory().create();
+    Document document = loader.loadDocument(SAXParserFactory::newInstance, is, null, errorHandler, 0, false, null);
+
+    assertThat(document, is(notNullValue()));
+    assertThat(errorHandler.getErrors().size(), is(0));
+
+    XmlMetadataAnnotations rootAnnotations =
+        (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(rootAnnotations, is(not(nullValue())));
+    assertThat(rootAnnotations.isSelfClosing(), is(false));
+    // FIXME: these are currently returning the beginning of the document instead of the beginning of the first tag
+    // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(2));
+    // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(1));
+    assertThat(rootAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(5));
+    assertThat(rootAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(108));
+
+    assertThat(rootAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(11));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(1));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(11));
+    assertThat(rootAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(8));
+
+    XmlMetadataAnnotations flowAnnotations =
+        (XmlMetadataAnnotations) document.getElementsByTagName("flow").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(flowAnnotations, is(not(nullValue())));
+    assertThat(flowAnnotations.isSelfClosing(), is(false));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(7));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(5));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(7));
+    assertThat(flowAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(23));
+
+    assertThat(flowAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(9));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(5));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(9));
+    assertThat(flowAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(12));
+
+    XmlMetadataAnnotations loggerAnnotations =
+        (XmlMetadataAnnotations) document.getElementsByTagName("logger").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+    assertThat(loggerAnnotations, is(not(nullValue())));
+    assertThat(loggerAnnotations.isSelfClosing(), is(true));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(8));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(9));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(8));
+    assertThat(loggerAnnotations.getOpeningTagBoundaries().getEndColumnNumber(), is(75));
+
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getStartLineNumber(), is(8));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getStartColumnNumber(), is(9));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getEndLineNumber(), is(8));
+    assertThat(loggerAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(75));
   }
 }

--- a/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
+++ b/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.mock;
 import static org.mule.runtime.dsl.internal.xml.parser.XmlMetadataAnnotations.METADATA_ANNOTATIONS_KEY;
@@ -60,7 +61,7 @@ public class MuleDocumentLoaderTestCase {
     verifyZeroInteractions(failing);
 
     assertThat(document, is(notNullValue()));
-    assertThat(errorHandler.getErrors().size(), is(0));
+    assertThat(errorHandler.getErrors(), is(empty()));
   }
 
   @Test
@@ -74,7 +75,7 @@ public class MuleDocumentLoaderTestCase {
     Document document = loader.loadDocument(SAXParserFactory::newInstance, is, null, errorHandler, 0, false, null);
 
     assertThat(document, is(notNullValue()));
-    assertThat(errorHandler.getErrors().size(), is(0));
+    assertThat(errorHandler.getErrors(), is(empty()));
 
     XmlMetadataAnnotations rootAnnotations =
         (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
@@ -132,7 +133,7 @@ public class MuleDocumentLoaderTestCase {
     Document document = loader.loadDocument(SAXParserFactory::newInstance, is, null, errorHandler, 0, false, null);
 
     assertThat(document, is(notNullValue()));
-    assertThat(errorHandler.getErrors().size(), is(0));
+    assertThat(errorHandler.getErrors(), is(empty()));
 
     XmlMetadataAnnotations rootAnnotations =
         (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);

--- a/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
+++ b/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
@@ -80,7 +80,7 @@ public class MuleDocumentLoaderTestCase {
         (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
     assertThat(rootAnnotations, is(not(nullValue())));
     assertThat(rootAnnotations.isSelfClosing(), is(false));
-    // FIXME: these are currently returning the beginning of the document instead of the beginning of the first tag
+    // FIXME MULE-19799: these are currently returning the beginning of the document instead of the beginning of the first tag
     // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(2));
     // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(1));
     assertThat(rootAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(5));
@@ -138,7 +138,7 @@ public class MuleDocumentLoaderTestCase {
         (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
     assertThat(rootAnnotations, is(not(nullValue())));
     assertThat(rootAnnotations.isSelfClosing(), is(false));
-    // FIXME: these are currently returning the beginning of the document instead of the beginning of the first tag
+    // FIXME MULE-19799: these are currently returning the beginning of the document instead of the beginning of the first tag
     // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(2));
     // assertThat(rootAnnotations.getOpeningTagBoundaries().getStartColumnNumber(), is(1));
     assertThat(rootAnnotations.getOpeningTagBoundaries().getEndLineNumber(), is(5));

--- a/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
+++ b/src/test/java/org/mule/runtime/dsl/internal/xml/parser/MuleDocumentLoaderTestCase.java
@@ -123,7 +123,8 @@ public class MuleDocumentLoaderTestCase {
   @Test
   public void xmlMetadataIsProperlyPopulatedWhenWhitespaceBetweenLineFeed() throws Exception {
 
-    InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("simple_application_with_whitespace_between_linefeed.xml");
+    InputStream inputStream =
+        currentThread().getContextClassLoader().getResourceAsStream("simple_application_with_whitespace_between_linefeed.xml");
     MuleDocumentLoader loader = new MuleDocumentLoader();
 
     InputSource is = new InputSource(inputStream);
@@ -134,7 +135,7 @@ public class MuleDocumentLoaderTestCase {
     assertThat(errorHandler.getErrors().size(), is(0));
 
     XmlMetadataAnnotations rootAnnotations =
-            (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
+        (XmlMetadataAnnotations) document.getDocumentElement().getUserData(METADATA_ANNOTATIONS_KEY);
     assertThat(rootAnnotations, is(not(nullValue())));
     assertThat(rootAnnotations.isSelfClosing(), is(false));
     // FIXME: these are currently returning the beginning of the document instead of the beginning of the first tag
@@ -149,7 +150,7 @@ public class MuleDocumentLoaderTestCase {
     assertThat(rootAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(8));
 
     XmlMetadataAnnotations flowAnnotations =
-            (XmlMetadataAnnotations) document.getElementsByTagName("flow").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+        (XmlMetadataAnnotations) document.getElementsByTagName("flow").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
     assertThat(flowAnnotations, is(not(nullValue())));
     assertThat(flowAnnotations.isSelfClosing(), is(false));
     assertThat(flowAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(9));
@@ -163,7 +164,7 @@ public class MuleDocumentLoaderTestCase {
     assertThat(flowAnnotations.getClosingTagBoundaries().getEndColumnNumber(), is(12));
 
     XmlMetadataAnnotations loggerAnnotations =
-            (XmlMetadataAnnotations) document.getElementsByTagName("logger").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
+        (XmlMetadataAnnotations) document.getElementsByTagName("logger").item(0).getUserData(METADATA_ANNOTATIONS_KEY);
     assertThat(loggerAnnotations, is(not(nullValue())));
     assertThat(loggerAnnotations.isSelfClosing(), is(true));
     assertThat(loggerAnnotations.getOpeningTagBoundaries().getStartLineNumber(), is(10));

--- a/src/test/resources/simple_application.xml
+++ b/src/test/resources/simple_application.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <flow name="test">
+        <logger category="SOMETHING" level="WARN" message="logging info"/>
+    </flow>
+
+</mule>

--- a/src/test/resources/simple_application_with_whitespace_between_linefeed.xml
+++ b/src/test/resources/simple_application_with_whitespace_between_linefeed.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <!-- this application contains superfluous white-spacing after this tag to trigger an edge case on the parser, don't remove -->    
+
+    <flow name="test">
+        <logger category="SOMETHING" level="WARN" message="logging info"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Also fixing some existing issues.
There is a pending issue with the location of the start of the opening tag of the root element. There was an issue before this anyways if the opening tag spanned across more than one line.