### PR TITLE
W-13517980: Revapi validation must point to latest stable version, not a

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 
         <revapi.maven.plugin.version>0.9.5</revapi.maven.plugin.version>
         <muleRevapiExtensionVersion>1.6.0-SNAPSHOT</muleRevapiExtensionVersion>
-        <oldMuleArtifactVersion>1.5.0-SNAPSHOT</oldMuleArtifactVersion>
+        <oldMuleArtifactVersion>1.4.0</oldMuleArtifactVersion>
 
         <license.maven.plugin.version>2.11</license.maven.plugin.version>
         <allureReportVersion>2.8.1</allureReportVersion>


### PR DESCRIPTION
snapshot