### PR TITLE
W-13637931: Fix paths so that windows builds work in addition to  builds in other OS

### DIFF
--- a/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
+++ b/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class ConfigResource {
 
   private static final List<String> CLASS_PATH_ENTRIES;
+  private static final boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
 
   static {
     String classPath = getProperty("java.class.path");
@@ -62,7 +63,8 @@ public final class ConfigResource {
     if (url.getProtocol().equals("jar")) {
       this.resourceName = url.toExternalForm().split("!/")[1];
     } else if (url.getProtocol().equals("file")) {
-      String updatedUrl = url.getPath().startsWith("/") ? url.getPath().substring(1) : url.getPath();
+      System.out.println("URL" + url.getPath());
+      String updatedUrl = isWindows && url.getPath().startsWith("/") ? url.getPath().substring(1) : url.getPath();
       this.resourceName = CLASS_PATH_ENTRIES.stream()
           .filter(cp -> updatedUrl.startsWith(cp)).findAny()
           .map(cp -> updatedUrl.substring(cp.length() + 1))

--- a/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
+++ b/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
@@ -63,7 +63,6 @@ public final class ConfigResource {
     if (url.getProtocol().equals("jar")) {
       this.resourceName = url.toExternalForm().split("!/")[1];
     } else if (url.getProtocol().equals("file")) {
-      System.out.println("URL" + url.getPath());
       String updatedUrl = isWindows && url.getPath().startsWith("/") ? url.getPath().substring(1) : url.getPath();
       this.resourceName = CLASS_PATH_ENTRIES.stream()
           .filter(cp -> updatedUrl.startsWith(cp)).findAny()

--- a/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
+++ b/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
@@ -62,7 +62,7 @@ public final class ConfigResource {
     if (url.getProtocol().equals("jar")) {
       this.resourceName = url.toExternalForm().split("!/")[1];
     } else if (url.getProtocol().equals("file")) {
-      String updatedUrl = url.getPath().startsWith("/")?url.getPath().substring(1):url.getPath();
+      String updatedUrl = url.getPath().startsWith("/") ? url.getPath().substring(1) : url.getPath();
       this.resourceName = CLASS_PATH_ENTRIES.stream()
           .filter(cp -> updatedUrl.startsWith(cp)).findAny()
           .map(cp -> updatedUrl.substring(cp.length() + 1))

--- a/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
+++ b/src/main/java/org/mule/runtime/dsl/api/ConfigResource.java
@@ -39,12 +39,13 @@ public final class ConfigResource {
     String modulePath = getProperty("jdk.module.path");
     String pathSeparator = getProperty("path.separator");
 
-    CLASS_PATH_ENTRIES = (modulePath != null
+    List<String> allClassPathEntries = (modulePath != null
         ? concat(Stream.of(classPath.split(pathSeparator)),
                  Stream.of(modulePath.split(pathSeparator)))
         : Stream.of(classPath.split(pathSeparator)))
             .filter(StringUtils::isNotBlank)
             .collect(toList());
+    CLASS_PATH_ENTRIES = allClassPathEntries.stream().map(line -> line.replace("\\", "/")).collect(toList());
   }
 
   protected String resourceName;
@@ -61,9 +62,10 @@ public final class ConfigResource {
     if (url.getProtocol().equals("jar")) {
       this.resourceName = url.toExternalForm().split("!/")[1];
     } else if (url.getProtocol().equals("file")) {
+      String updatedUrl = url.getPath().startsWith("/")?url.getPath().substring(1):url.getPath();
       this.resourceName = CLASS_PATH_ENTRIES.stream()
-          .filter(cp -> url.getPath().startsWith(cp)).findAny()
-          .map(cp -> url.getPath().substring(cp.length() + 1))
+          .filter(cp -> updatedUrl.startsWith(cp)).findAny()
+          .map(cp -> updatedUrl.substring(cp.length() + 1))
           .orElse(url.toExternalForm());
     } else {
       this.resourceName = url.toExternalForm();


### PR DESCRIPTION
In windows CP entried were using \, for eg `C:\Users\Administrator\.m2\abc\`  this had to be changed to / so that resourceName is computed correctly and not as full path for eg.  `\C:\Users\Administrator\jenkins-agent\workspace\mainfb3d0e90\mule-artifact-ast\mule-ast-xml-parser\target\est-classes\import-from-dependency.xml `which was causing failure in Windows build tests.